### PR TITLE
Add okex account position, margin, leverage config

### DIFF
--- a/src/ExchangeBase.ts
+++ b/src/ExchangeBase.ts
@@ -45,14 +45,10 @@ export abstract class ExchangeBase {
     const exchangeClass = ccxt[this.exchangeId]
     this.exchange = new exchangeClass({ apiKey, secret, password })
 
-    if (this.exchange.options) {
-      this.exchange.options["createMarketBuyOrderRequiresPrice"] = false
-    }
+    this.exchange.options["createMarketBuyOrderRequiresPrice"] = false
 
     // The following check throws if something is wrong
     this.exchange.checkRequiredCredentials()
-
-    this.setAccountConfiguration()
 
     this.logger = logger.child({ class: `${ExchangeBase.name}-${this.exchangeId}` })
   }

--- a/src/ExchangeBase.ts
+++ b/src/ExchangeBase.ts
@@ -17,6 +17,7 @@ import {
   FetchDepositsParameters,
   OrderStatus,
   GetPublicFundingRateResult,
+  SetAccountConfigurationResult,
 } from "./ExchangeTradingType"
 import { Result } from "./Result"
 import ccxt, { ExchangeId } from "ccxt"
@@ -29,7 +30,7 @@ export abstract class ExchangeBase {
   exchange: ccxt.okex5
   logger: pino.Logger
 
-  constructor(exchangeConfig: ExchangeConfiguration, logger) {
+  constructor(exchangeConfig: ExchangeConfiguration, logger: pino.Logger) {
     this.exchangeConfig = exchangeConfig
     this.exchangeId = exchangeConfig.exchangeId as ExchangeId
 
@@ -50,6 +51,8 @@ export abstract class ExchangeBase {
 
     // The following check throws if something is wrong
     this.exchange.checkRequiredCredentials()
+
+    this.setAccountConfiguration()
 
     this.logger = logger.child({ class: `${ExchangeBase.name}-${this.exchangeId}` })
   }
@@ -384,4 +387,6 @@ export abstract class ExchangeBase {
   abstract getInstrumentDetails(): Promise<Result<GetInstrumentDetailsResult>>
 
   abstract getPublicFundingRate(): Promise<Result<GetPublicFundingRateResult>>
+
+  abstract setAccountConfiguration(): Promise<Result<SetAccountConfigurationResult>>
 }

--- a/src/ExchangeTradingType.ts
+++ b/src/ExchangeTradingType.ts
@@ -183,6 +183,10 @@ export interface GetPublicFundingRateResult {
   nextFundingRate: number
 }
 
+export interface SetAccountConfigurationResult {
+  originalResponseAsIs
+}
+
 export enum ApiError {
   NOT_IMPLEMENTED = "Not Implemented",
   NOT_SUPPORTED = "Not Supported",
@@ -195,6 +199,8 @@ export enum ApiError {
   MISSING_PARAMETERS = "Missing Parameters",
   NON_POSITIVE_QUANTITY = "Non Positive Quantity",
   INVALID_TRADE_SIDE = "Invalid Trade Side",
+  INVALID_POSITION_MODE = "Invalid Position Mode",
+  INVALID_LEVERAGE_CONFIG = "Invalid Leverage Configuration",
   MISSING_ORDER_ID = "Missing Order Id",
   NON_POSITIVE_PRICE = "Non Positive Price",
   NON_POSITIVE_NOTIONAL = "Non Positive Notional",

--- a/src/OkexExchange.ts
+++ b/src/OkexExchange.ts
@@ -4,16 +4,19 @@ import {
   TradeCurrency,
   ApiError,
   GetPublicFundingRateResult,
+  SetAccountConfigurationResult,
 } from "./ExchangeTradingType"
 import assert from "assert"
 import { ExchangeBase } from "./ExchangeBase"
-import { ExchangeConfiguration } from "./ExchangeConfiguration"
+import { ExchangeConfiguration, SupportedInstrument } from "./ExchangeConfiguration"
+import { OkexExchangeConfiguration } from "./OkexExchangeConfiguration"
 import { Result } from "./Result"
+import pino from "pino"
 
 export class OkexExchange extends ExchangeBase {
-  instrumentId
+  instrumentId: SupportedInstrument
 
-  constructor(exchangeConfiguration: ExchangeConfiguration, logger) {
+  constructor(exchangeConfiguration: ExchangeConfiguration, logger: pino.Logger) {
     super(exchangeConfiguration, logger)
     this.instrumentId = exchangeConfiguration.instrumentId
   }
@@ -138,6 +141,53 @@ export class OkexExchange extends ExchangeBase {
       }
     } catch (error) {
       return { ok: false, error: error }
+    }
+  }
+
+  public async setAccountConfiguration(): Promise<Result<SetAccountConfigurationResult>> {
+    const config = this.exchangeConfig as OkexExchangeConfiguration
+
+    const args1 = { posMode: config.positionMode }
+    const positionResponse = await this.exchange.privatePostAccountSetPositionMode(args1)
+    this.logger.debug(
+      { args: args1, response: positionResponse },
+      "exchange.privatePostAccountSetPositionMode({args}) returned: {response}",
+    )
+    assert(positionResponse, ApiError.UNSUPPORTED_API_RESPONSE)
+    assert(
+      positionResponse.data[0].posMode === args1.posMode,
+      ApiError.INVALID_POSITION_MODE,
+    )
+
+    const args2 = {
+      instId: this.instrumentId,
+      lever: config.leverage,
+      mgnMode: config.marginMode,
+    }
+    const leverageResponse = await this.exchange.privatePostAccountSetLeverage(args2)
+    this.logger.debug(
+      { args: args2, response: leverageResponse },
+      "exchange.privatePostAccountSetLeverage({args}) returned: {response}",
+    )
+    assert(leverageResponse, ApiError.UNSUPPORTED_API_RESPONSE)
+    assert(
+      leverageResponse.data[0].instId === args2.instId.toString(),
+      ApiError.INVALID_LEVERAGE_CONFIG,
+    )
+    assert(
+      leverageResponse.data[0].lever === args2.lever.toString(),
+      ApiError.INVALID_LEVERAGE_CONFIG,
+    )
+    assert(
+      leverageResponse.data[0].mgnMode === args2.mgnMode.toString(),
+      ApiError.INVALID_LEVERAGE_CONFIG,
+    )
+
+    return {
+      ok: true,
+      value: {
+        originalResponseAsIs: { positionResponse, leverageResponse },
+      },
     }
   }
 }

--- a/src/OkexExchangeConfiguration.ts
+++ b/src/OkexExchangeConfiguration.ts
@@ -24,14 +24,33 @@ import {
   SupportedInstrument,
 } from "./ExchangeConfiguration"
 import { sat2btc } from "./utils"
+import { yamlConfig } from "./config"
+
+export enum PositionMode {
+  LongShort = "long_short_mode",
+  Net = "net_mode",
+}
+
+export enum MarginMode {
+  Isolated = "isolated",
+  Cross = "cross",
+}
+
+const hedgingBounds = yamlConfig.hedging
 
 export class OkexExchangeConfiguration implements ExchangeConfiguration {
   exchangeId: SupportedExchange
   instrumentId: SupportedInstrument
+  positionMode: PositionMode
+  marginMode: MarginMode
+  leverage: number
 
   constructor() {
     this.exchangeId = SupportedExchange.OKEX5
     this.instrumentId = SupportedInstrument.OKEX_PERPETUAL_SWAP
+    this.positionMode = PositionMode.Net
+    this.marginMode = MarginMode.Isolated
+    this.leverage = hedgingBounds.HIGH_BOUND_LEVERAGE
   }
 
   fetchDepositAddressValidateInput(currency: string) {

--- a/src/OkexPerpetualSwapStrategy.ts
+++ b/src/OkexPerpetualSwapStrategy.ts
@@ -73,6 +73,10 @@ export class OkexPerpetualSwapStrategy implements HedgingStrategy {
     this.exchange = new OkexExchange(this.exchangeConfig, logger)
     this.instrumentId = this.exchangeConfig.instrumentId
     this.logger = logger.child({ class: OkexPerpetualSwapStrategy.name })
+
+    if (!this.isSimulation) {
+      this.exchange.setAccountConfiguration()
+    }
   }
 
   public async getBtcSpotPriceInUsd(): Promise<Result<number>> {

--- a/test/mocks/ExchangeApiResponseHelper.ts
+++ b/test/mocks/ExchangeApiResponseHelper.ts
@@ -1,5 +1,7 @@
 import dateFormat from "dateformat"
+import { SupportedInstrument } from "src/ExchangeConfiguration"
 import { OrderStatus, FundTransferStatus, TradeCurrency } from "src/ExchangeTradingType"
+import { MarginMode, PositionMode } from "src/OkexExchangeConfiguration"
 
 export const DATE_FORMAT_STRING = "yyyymmddHHMMss"
 
@@ -156,6 +158,38 @@ export function getValidPublicGetPublicInstrumentsResponse({ instType, instId })
         ctValCcy: `${contractValueCurrency}`,
         instId: `${instId}`,
         instType: `${instType}`,
+      },
+    ],
+    msg: "",
+  }
+}
+
+export function getValidPrivatePostAccountSetPositionModeResponse(args: {
+  posMode: PositionMode
+}) {
+  return {
+    code: "0",
+    data: [
+      {
+        posMode: `${args.posMode}`,
+      },
+    ],
+    msg: "",
+  }
+}
+
+export function getValidPrivatePostAccountSetLeverageResponse(args: {
+  instrumentId: SupportedInstrument
+  lever: number
+  marginMode: MarginMode
+}) {
+  return {
+    code: "0",
+    data: [
+      {
+        instId: `${args.instrumentId}`,
+        lever: `${args.lever}`,
+        mgnMode: `${args.marginMode}`,
       },
     ],
     msg: "",

--- a/test/mocks/OkexScenarioStepBuilder.ts
+++ b/test/mocks/OkexScenarioStepBuilder.ts
@@ -21,8 +21,12 @@ import {
   getValidFetchPositionResponse,
   getValidFetchTickerResponse,
   getValidPublicGetPublicInstrumentsResponse,
+  getValidPrivatePostAccountSetLeverageResponse,
+  getValidPrivatePostAccountSetPositionModeResponse,
 } from "./ExchangeApiResponseHelper"
 import { yamlConfig } from "src/config"
+import { MarginMode, PositionMode } from "src/OkexExchangeConfiguration"
+import { SupportedInstrument } from "src/ExchangeConfiguration"
 
 const hedgingBounds = yamlConfig.hedging
 
@@ -57,6 +61,8 @@ export interface StepInput {
 export interface ExchangeMock {
   options: jest.Mock
   checkRequiredCredentials: jest.Mock
+  privatePostAccountSetPositionMode: jest.Mock
+  privatePostAccountSetLeverage: jest.Mock
   last_json_response: jest.Mock
   fetchDeposits: jest.Mock
   fetchWithdrawals: jest.Mock
@@ -111,6 +117,8 @@ export class OkexScenarioStepBuilder {
           new Map<string, boolean>([["createMarketBuyOrderRequiresPrice", true]]),
         ),
       checkRequiredCredentials: jest.fn().mockReturnValue(true),
+      privatePostAccountSetPositionMode: jest.fn(),
+      privatePostAccountSetLeverage: jest.fn(),
       last_json_response: jest
         .fn()
         .mockReturnValue(new Map<string, number>([["cursor", 0]])),
@@ -254,6 +262,24 @@ export class OkexScenarioStepBuilder {
     //     Else // deposit
     //         exchange.fetchDepositAddress()
     //         wallet.payOnChain()
+
+    // Init
+    exchangeMock.privatePostAccountSetPositionMode.mockImplementationOnce(
+      (args: { posMode: PositionMode }) => {
+        return getValidPrivatePostAccountSetPositionModeResponse({
+          posMode: args.posMode,
+        })
+      },
+    )
+    exchangeMock.privatePostAccountSetLeverage.mockImplementationOnce(
+      (args: { instId: SupportedInstrument; lever: number; mgnMode: MarginMode }) => {
+        return getValidPrivatePostAccountSetLeverageResponse({
+          instrumentId: args.instId,
+          lever: args.lever,
+          marginMode: args.mgnMode,
+        })
+      },
+    )
 
     // Update in-flight
     if (wasFundTransferExpected) {

--- a/test/unit/OkexExchange.spec.ts
+++ b/test/unit/OkexExchange.spec.ts
@@ -1,18 +1,16 @@
 import { baseLogger } from "src/services/logger"
 import { SupportedExchange, SupportedInstrument } from "src/ExchangeConfiguration"
-import { OkexExchangeConfiguration } from "src/OkexExchangeConfiguration"
+import {
+  MarginMode,
+  OkexExchangeConfiguration,
+  PositionMode,
+} from "src/OkexExchangeConfiguration"
 import { OkexExchange } from "src/OkexExchange"
 import {
-  WithdrawParameters,
-  CreateOrderParameters,
-  SupportedChain,
-  TradeCurrency,
-  TradeSide,
-  TradeType,
-  ApiError,
-  OrderStatus,
-} from "src/ExchangeTradingType"
-import { AssertionError } from "assert"
+  getValidPrivatePostAccountSetLeverageResponse,
+  getValidPrivatePostAccountSetPositionModeResponse,
+} from "../mocks/ExchangeApiResponseHelper"
+import { TradeCurrency, ApiError } from "src/ExchangeTradingType"
 
 beforeAll(async () => {
   // Init exchange secrets
@@ -73,6 +71,32 @@ const falsyArgs = [null, undefined, NaN, 0, "", false]
 
 const exchangeMock = {
   checkRequiredCredentials: jest.fn().mockReturnValue(true),
+
+  options: jest
+    .fn()
+    .mockReturnValue(
+      new Map<string, boolean>([["createMarketBuyOrderRequiresPrice", true]]),
+    ),
+  privatePostAccountSetPositionMode: jest
+    .fn()
+    .mockImplementation((args: { posMode: PositionMode }) => {
+      return getValidPrivatePostAccountSetPositionModeResponse({
+        posMode: args.posMode,
+      })
+    }),
+  privatePostAccountSetLeverage: jest
+    .fn()
+    .mockImplementation(
+      (args: { instId: SupportedInstrument; lever: number; mgnMode: MarginMode }) => {
+        return getValidPrivatePostAccountSetLeverageResponse({
+          instrumentId: args.instId,
+          lever: args.lever,
+          marginMode: args.mgnMode,
+        })
+      },
+    ),
+  last_json_response: jest.fn().mockReturnValue(new Map<string, number>([["cursor", 0]])),
+
   fetchPosition: jest.fn(),
   fetchBalance: jest.fn(),
   publicGetPublicInstruments: jest.fn(),


### PR DESCRIPTION
Add okex account position mode configuration so we only deal with a net position and not multiple long & short at different entry points.
Add okex margin mode configuration to the simpler to manage isolated vs cross currency mode.
Add leverage configuration.
Default might differ and would need to be manually set otherwise.
Other api calls rely on these configuration to be successful.