### PR TITLE
[ci] Adding Pipeline Tasks

### DIFF
--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -1,0 +1,14 @@
+name: "Check code"
+on:
+  pull_request:
+    branches: [ main ]
+jobs:
+  check-code:
+    name: Check Code
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+    - run: yarn install
+    - name: Run check code
+      run: make check-code

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,0 +1,17 @@
+name: "Integration test"
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  integration:
+    name: Integration test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+    - run: yarn install
+    - name: Run integration tests
+      run: docker-compose up -d && make integration-in-ci

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,0 +1,16 @@
+name: "Unit test"
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  unit-test:
+    name: Unit test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+    - run: yarn install
+    - name: Run unit tests
+      run: make unit-in-ci

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+BIN_DIR=node_modules/.bin
+
 test: unit integration
 
 unit:
@@ -10,6 +12,14 @@ test-in-ci:
 	docker-compose up -d
 	. ./.envrc && \
 		LOGLEVEL=error node_modules/.bin/jest --bail --runInBand --ci --reporters=default --reporters=jest-junit
+
+integration-in-ci:
+	. ./.envrc && \
+		LOGLEVEL=error $(BIN_DIR)/jest --config ./test/jest-integration.config.js --bail --runInBand --ci --reporters=default --reporters=jest-junit
+
+unit-in-ci:
+	. ./.envrc && \
+		LOGLEVEL=warn $(BIN_DIR)/jest --config ./test/jest-unit.config.js --ci --bail
 
 check-code:
 	yarn tsc-check

--- a/ci/image/Dockerfile
+++ b/ci/image/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:14-alpine
+
+RUN apk update \
+  && apk add bash make git docker curl python jq rsync openssh wget
+
+# Install gcloud
+RUN curl -sSL https://sdk.cloud.google.com | bash
+ENV PATH $PATH:/root/google-cloud-sdk/bin
+
+RUN mkdir ghcli && cd ghcli \
+  && wget https://github.com/cli/cli/releases/download/v2.0.0/gh_2.0.0_linux_386.tar.gz -O ghcli.tar.gz \
+  && tar --strip-components=1 -xf ghcli.tar.gz \
+  && mv bin/gh /usr/local/bin && cd ../ && rm -rf ./ghcli

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,0 +1,295 @@
+#@ load("@ytt:data", "data")
+
+#@ def pipeline_image():
+#@   return data.values.docker_registry + "/galoy-app-pipeline"
+#@ end
+
+#@ def dealer_image():
+#@   return data.values.docker_registry + "/dealer"
+#@ end
+
+#@ def fake_galoyapi_image():
+#@   return data.values.docker_registry + "/fake-galoyapi"
+#@ end
+
+#@ def task_image_config():
+type: registry-image
+source:
+  username: #@ data.values.docker_registry_user
+  password: #@ data.values.docker_registry_password
+  repository: #@ pipeline_image()
+#@ end
+
+groups:
+- name: dealer
+  jobs:
+  - install-deps
+  - test-integration
+  - test-unit
+  - check-code
+  - build-dealer-image
+  - build-fake-galoyapi-image
+  - bump-image-in-chart
+
+jobs:
+- name: install-deps
+  plan:
+  - in_parallel:
+    - {get: deps, trigger: true}
+    - {get: pipeline-tasks}
+    - {put: deps-version, params: {bump: patch}}
+  - task: install-deps
+    config:
+      platform: linux
+      image_resource: #@ task_image_config()
+      inputs:
+      - name: pipeline-tasks
+      - name: deps
+      - name: deps-version
+      outputs:
+      - name: bundled-deps
+      run:
+        path: pipeline-tasks/ci/tasks/install-deps.sh
+  - put: bundled-deps
+    params:
+      file: bundled-deps/bundled-deps-*.tgz
+
+- name: test-integration
+  serial: true
+  plan:
+  - in_parallel:
+    - { get: repo, trigger: true }
+    - { get: pipeline-tasks }
+    - { get: bundled-deps, trigger: true }
+  - task: test-integration
+    config:
+      platform: linux
+      image_resource: #@ task_image_config()
+      inputs:
+      - name: bundled-deps
+      - name: pipeline-tasks
+      - name: repo
+      params:
+        DOCKER_HOST_IP: #@ data.values.docker_host_ip
+        GOOGLE_CREDENTIALS: #@ data.values.staging_inception_creds
+        SSH_PRIVATE_KEY: #@ data.values.staging_ssh_private_key
+        SSH_PUB_KEY: #@ data.values.staging_ssh_pub_key
+        JEST_TIMEOUT: 60000
+      run:
+        path: pipeline-tasks/ci/tasks/test-integration.sh
+
+- name: test-unit
+  serial: true
+  plan:
+  - in_parallel:
+    - { get: repo, trigger: true }
+    - { get: pipeline-tasks }
+    - { get: bundled-deps, trigger: true }
+  - task: test-unit
+    config:
+      platform: linux
+      image_resource: #@ task_image_config()
+      inputs:
+      - name: bundled-deps
+      - name: pipeline-tasks
+      - name: repo
+      run:
+        path: pipeline-tasks/ci/tasks/test-unit.sh
+
+- name: check-code
+  serial: true
+  plan:
+  - in_parallel:
+    - { get: repo, trigger: true }
+    - { get: pipeline-tasks }
+    - { get: bundled-deps, trigger: true}
+  - task: check-code
+    config:
+      platform: linux
+      image_resource: #@ task_image_config()
+      inputs:
+      - name: bundled-deps
+      - name: pipeline-tasks
+      - name: repo
+      run:
+        path: pipeline-tasks/ci/tasks/check-code.sh
+
+- name: build-dealer-image
+  serial: true
+  plan:
+  - get: repo
+    trigger: true
+  - task: build
+    privileged: true
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      inputs:
+      - name: repo
+      outputs:
+      - name: image
+      params:
+        CONTEXT: repo
+        DOCKERFILE: "repo/src/app/Dockerfile"
+      run:
+        path: build
+  - put: dealer-image
+    params:
+      image: image/image.tar
+
+- name: build-fake-galoyapi-image
+  serial: true
+  plan:
+  - get: repo
+    trigger: true
+  - task: build
+    privileged: true
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      inputs:
+      - name: repo
+      outputs:
+      - name: image
+      params:
+        CONTEXT: repo
+        DOCKERFILE: "repo/src/servers/graphql/Dockerfile"
+      run:
+        path: build
+  - put: fake-galoyapi-image
+    params:
+      image: image/image.tar
+
+- name: bump-image-in-chart
+  plan:
+  - in_parallel:
+    - get: dealer-image
+      trigger: true
+      passed: [ build-dealer-image ]
+      params: { skip_download: true }
+    - get: fake-galoyapi-image
+      trigger: true
+      passed: [ build-fake-galoyapi-image ]
+      params: { skip_download: true }
+    - get: repo
+      trigger: true
+      passed:
+      - check-code
+      - test-unit
+      - test-integration
+      - build-dealer-image
+      - build-fake-galoyapi-image
+    - get: charts-repo
+      params: { skip_download: true }
+    - get: pipeline-tasks
+  - task: bump-image-digest-in-values
+    config:
+      platform: linux
+      image_resource: #@ task_image_config()
+      inputs:
+      - name: repo
+      - name: dealer-image
+      - name: fake-galoyapi-image
+      - name: charts-repo
+      outputs:
+      - name: charts-repo
+      params:
+        BRANCH: #@ data.values.git_charts_branch
+      run:
+        path: pipeline-tasks/ci/tasks/bump-image-digest.sh
+  - put: charts-repo-bot-branch
+    params:
+      repository: charts-repo
+      force: true
+  - task: open-charts-pr
+    config:
+      platform: linux
+      image_resource: #@ task_image_config()
+      inputs:
+      - name: pipeline-tasks
+      - name: dealer-image
+      - name: fake-galoyapi-image
+      - name: charts-repo
+      params:
+        GH_TOKEN: #@ data.values.github_token
+        BRANCH: #@ data.values.git_charts_branch
+        BOT_BRANCH: #@ data.values.git_charts_bot_branch
+      run:
+        path: pipeline-tasks/ci/tasks/open-charts-pr.sh
+
+resources:
+- name: repo
+  type: git
+  source:
+    ignore_paths: ["ci/*[^md]"]
+    uri: #@ data.values.git_uri
+    branch: #@ data.values.git_branch
+    private_key: #@ data.values.github_private_key
+
+- name: pipeline-tasks
+  type: git
+  source:
+    paths: [ci/tasks/*, Makefile]
+    uri: #@ data.values.git_uri
+    branch: #@ data.values.git_branch
+    private_key: #@ data.values.github_private_key
+
+- name: charts-repo-bot-branch
+  type: git
+  source:
+    uri: #@ data.values.git_charts_uri
+    branch: #@ data.values.git_charts_bot_branch
+    private_key: #@ data.values.github_private_key
+
+- name: charts-repo
+  type: git
+  source:
+    uri: #@ data.values.git_charts_uri
+    branch: #@ data.values.git_charts_branch
+    private_key: #@ data.values.github_private_key
+
+- name: deps
+  type: git
+  source:
+    paths: [yarn.lock]
+    uri: #@ data.values.git_uri
+    branch: #@ data.values.git_branch
+    private_key: #@ data.values.github_private_key
+
+- name: deps-version
+  type: semver
+  source:
+    initial_version: 0.1.0
+    driver: gcs
+    bucket: #@ data.values.artifacts_bucket_name
+    key: galoy-dealer-artifacts/versions/deps
+    json_key: #@ data.values.staging_inception_creds
+
+- name: bundled-deps
+  type: gcs-resource
+  source:
+    bucket: #@ data.values.artifacts_bucket_name
+    json_key: #@ data.values.staging_inception_creds
+    regexp: galoy-dealer-artifacts/deps/bundled-deps-v(.*)-.*.tgz
+
+- name: dealer-image
+  type: registry-image
+  source:
+    tag: dealer
+    username: #@ data.values.docker_registry_user
+    password: #@ data.values.docker_registry_password
+    repository: #@ dealer_image()
+
+- name: fake-galoyapi-image
+  type: registry-image
+  source:
+    tag: fake-galoyapi
+    username: #@ data.values.docker_registry_user
+    password: #@ data.values.docker_registry_password
+    repository: #@ fake_galoyapi_image()

--- a/ci/repipe
+++ b/ci/repipe
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+if [[ $(which ytt) == "" ]]; then
+  echo "You will need to install ytt to repipe. https://carvel.dev/ytt/"
+  exit 1
+fi
+
+target="${FLY_TARGET:-galoy}"
+team=dev
+
+TMPDIR=""
+TMPDIR=$(mktemp -d -t repipe.XXXXXX)
+trap "rm -rf ${TMPDIR}" INT TERM QUIT EXIT
+
+ytt -f ci > ${TMPDIR}/pipeline.yml
+
+echo "Updating pipeline @ ${target}"
+
+fly -t ${target} set-pipeline --team=${team} -p dealer -c ${TMPDIR}/pipeline.yml
+fly -t ${target} unpause-pipeline --team=${team} -p dealer

--- a/ci/tasks/bump-image-digest.sh
+++ b/ci/tasks/bump-image-digest.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+# TODO: Open a PR to Charts Repo

--- a/ci/tasks/check-code.sh
+++ b/ci/tasks/check-code.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -eu
+
+. pipeline-tasks/ci/tasks/helpers.sh
+
+unpack_deps
+
+
+pushd repo
+
+make check-code

--- a/ci/tasks/helpers.sh
+++ b/ci/tasks/helpers.sh
@@ -1,0 +1,18 @@
+function unpack_deps() {
+
+  echo "Unpacking deps... "
+
+  tar -zxvf bundled-deps/bundled-deps-*.tgz ./node_modules/ ./yarn.lock -C repo/ > /dev/null
+
+  pushd repo > /dev/null
+
+  if [[ "$(git status -s -uno)" != "" ]]; then
+    echo "Extracting deps has created a diff - deps are not in sync"
+    git --no-pager diff
+    exit 1;
+  fi
+
+  echo "Done!"
+
+  popd
+}

--- a/ci/tasks/install-deps.sh
+++ b/ci/tasks/install-deps.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -eu
+
+tar_out="$(pwd)/bundled-deps"
+
+pushd deps
+yarn install
+git log --pretty=format:'%h' -n 1 > gitref
+
+tar -zcvf "${tar_out}/bundled-deps-v$(cat ../deps-version/number)-$(cat gitref).tgz" . > /dev/null
+
+popd

--- a/ci/tasks/open-charts-pr.sh
+++ b/ci/tasks/open-charts-pr.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+# TODO: Open a PR to Charts Repo

--- a/ci/tasks/test-integration.sh
+++ b/ci/tasks/test-integration.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -eu
+
+. pipeline-tasks/ci/tasks/helpers.sh
+
+unpack_deps
+
+CI_ROOT=$(pwd)
+
+cat <<EOF > ${CI_ROOT}/gcloud-creds.json
+${GOOGLE_CREDENTIALS}
+EOF
+cat <<EOF > ${CI_ROOT}/login.ssh
+${SSH_PRIVATE_KEY}
+EOF
+chmod 600 ${CI_ROOT}/login.ssh
+cat <<EOF > ${CI_ROOT}/login.ssh.pub
+${SSH_PUB_KEY}
+EOF
+gcloud auth activate-service-account --key-file ${CI_ROOT}/gcloud-creds.json
+gcloud compute os-login ssh-keys add --key-file=${CI_ROOT}/login.ssh.pub > /dev/null
+
+mkdir ~/.ssh
+cp ${CI_ROOT}/login.ssh ~/.ssh/id_rsa
+cp ${CI_ROOT}/login.ssh.pub ~/.ssh/id_rsa.pub
+
+export DOCKER_HOST_USER="sa_$(cat ${CI_ROOT}/gcloud-creds.json  | jq -r '.client_id')"
+export ADDITIONAL_SSH_OPTS="-o StrictHostKeyChecking=no -i ${CI_ROOT}/login.ssh"
+
+echo "Syncing repo to docker-host... "
+rsync --delete -avr -e "ssh -l ${DOCKER_HOST_USER} ${ADDITIONAL_SSH_OPTS}" \
+  repo/ ${DOCKER_HOST_IP}:repo > /dev/null
+echo "Done!"
+
+ssh ${ADDITIONAL_SSH_OPTS} ${DOCKER_HOST_USER}@${DOCKER_HOST_IP} \
+  "cd repo; docker ps -aq | xargs docker rm -vf; DOCKER_HOST_IP=${DOCKER_HOST_IP} docker-compose up -d"
+
+export DOCKER_HOST=ssh://${DOCKER_HOST_USER}@${DOCKER_HOST_IP}
+
+pushd repo
+
+make integration-in-ci

--- a/ci/tasks/test-unit.sh
+++ b/ci/tasks/test-unit.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -eu
+
+. pipeline-tasks/ci/tasks/helpers.sh
+
+unpack_deps
+
+pushd repo
+
+make unit-in-ci

--- a/ci/values.yml
+++ b/ci/values.yml
@@ -1,0 +1,18 @@
+#@data/values
+---
+git_uri: git@github.com:GaloyMoney/dealer.git
+git_branch: main
+git_charts_uri: git@github.com:GaloyMoney/charts.git
+git_charts_branch: main
+git_charts_bot_branch: bot-bump-dealer-image
+github_private_key: ((github.private_key))
+github_token: ((github.api_token))
+docker_registry: us.gcr.io/galoy-org
+docker_registry_user: ((docker-creds.username))
+docker_registry_password: ((docker-creds.password))
+docker_host_ip: ((staging-ssh.docker_host_ip))
+artifacts_bucket_name: ((staging-gcp-creds.bucket_name))
+staging_inception_creds: ((staging-gcp-creds.creds_json))
+staging_ssh_private_key: ((staging-ssh.ssh_private_key))
+staging_ssh_pub_key: ((staging-ssh.ssh_public_key))
+


### PR DESCRIPTION
Adds:
1. Concourse CI tasks:
   - Run unit and integration tests (on cached deps)
   - Build the 2 docker images present on this repo and push to registry
2. GitHub Action to run the unit and integration tests on each PR

Todo:
1. Update the dealer charts' git ref in [GaloyMoney/charts](https://github.com/GaloyMoney/charts). Will work on it after the dealer charts are complete.