### PR TITLE
ci: added vendir sync for common tasks, starting with release script

### DIFF
--- a/ci/config/vendor/git-cliff.toml
+++ b/ci/config/vendor/git-cliff.toml
@@ -1,0 +1,54 @@
+# configuration file for git-cliff (0.1.0)
+
+[changelog]
+# changelog header
+header = """"""
+
+# template for the changelog body
+# https://tera.netlify.app/docs/#introduction
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | upper_first }}
+    {% for commit in commits %}
+        - {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | upper_first }}\
+    {% endfor %}
+{% endfor %}\n
+"""
+# remove the leading and trailing whitespaces from the template
+trim = true
+# changelog footer
+footer = """"""
+
+[git]
+# parse the commits based on https://www.conventionalcommits.org
+conventional_commits = true
+# filter out the commits that are not conventional
+filter_unconventional = true
+# regex for parsing and grouping commits
+commit_parsers = [
+    { message = "^feat", group = "Features"},
+    { message = "^fix", group = "Bug Fixes"},
+    { message = "^doc", group = "Documentation"},
+    { message = "^perf", group = "Performance"},
+    { message = "^refactor", group = "Refactor"},
+    { message = "^style", group = "Styling"},
+    { message = "^test", group = "Testing"},
+    { message = "^chore\\(release\\): prepare for", skip = true},
+    { message = "^chore", group = "Miscellaneous Tasks"},
+    { body = ".*security", group = "Security"},
+]
+# filter out the commits that are not matched by commit parsers
+filter_commits = true
+# glob pattern for matching git tags
+tag_pattern = "v[0-9]*"
+# regex for skipping tags
+skip_tags = "v0.1.0-beta.1"
+# regex for ignoring tags
+ignore_tags = ""
+# sort the tags topologically
+topo_order = false
+# sort the commits inside sections by oldest/newest order
+sort_commits = "newest"

--- a/ci/tasks/vendor/prep-release-src.sh
+++ b/ci/tasks/vendor/prep-release-src.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -eu
+
+# ------------ CHANGELOG ------------
+
+pushd repo
+
+# First time
+if [[ $(cat version/version) == "0.0.0" ]]; then
+  git cliff --config ci/vendor/config/git-cliff.toml > ../artifacts/gh-release-notes.md
+
+# Fetch changelog from last ref
+else
+  export prev_ref=$(git rev-list -n 1 $(cat version/version))
+  export new_ref=$(cd repo && git rev-parse HEAD)
+
+  git cliff --config ci/vendor/config/git-cliff.toml $prev_ref..$new_ref > ../artifacts/gh-release-notes.md
+fi
+
+popd
+
+# Generate Changelog
+echo "CHANGELOG:"
+echo "-------------------------------"
+cat artifacts/gh-release-notes.md
+echo "-------------------------------"
+
+# ------------ BUMP VERSION ------------
+
+echo -n "Prev Version: "
+cat version/version
+echo ""
+
+# Initial Version
+if [[ $(cat version/version) == "0.0.0" ]]; then
+  echo "0.1.0" > version/version
+# Figure out proper version to release
+elif [[ $(cat artifacts/gh-release-notes.md | grep breaking) != '' ]] || [[ $(cat artifacts/gh-release-notes.md | grep feature) != '' ]]; then
+  echo "Breaking change / Feature Addition found, bumping minor version..."
+  bump2version minor --current-version $(cat version/version) --allow-dirty version/version
+else
+  echo "Only patches and fixes found - no breaking changes, bumping patch version..."
+  bump2version patch --current-version $(cat version/version) --allow-dirty version/version
+fi
+
+echo -n "Release Version: "
+cat version/version
+echo ""
+
+# ------------ ARTIFACTS ------------
+
+cat version/version > artifacts/gh-release-tag
+echo "v$(cat version/version) Release" > artifacts/gh-release-name

--- a/ci/vendir.lock.yml
+++ b/ci/vendir.lock.yml
@@ -1,0 +1,17 @@
+apiVersion: vendir.k14s.io/v1alpha1
+directories:
+- contents:
+  - git:
+      commitTitle: 'feat: added git cliff config and prep release source code task
+        (#1)'
+      sha: b71d51f8293ef74c23d7ad5ff97c92fa3ea66a2e
+    path: .
+  path: tasks/vendor
+- contents:
+  - git:
+      commitTitle: 'feat: added git cliff config and prep release source code task
+        (#1)'
+      sha: b71d51f8293ef74c23d7ad5ff97c92fa3ea66a2e
+    path: .
+  path: config/vendor
+kind: LockConfig

--- a/ci/vendir.yml
+++ b/ci/vendir.yml
@@ -1,0 +1,23 @@
+apiVersion: vendir.k14s.io/v1alpha1
+kind: Config
+
+directories:
+- path: tasks/vendor
+  contents:
+  - path: .
+    git:
+      url: https://github.com/GaloyMoney/concourse-shared.git
+      ref: b71d51f8293ef74c23d7ad5ff97c92fa3ea66a2e
+    includePaths:
+    - tasks/**/*
+    newRootPath: tasks
+
+- path: config/vendor
+  contents:
+  - path: .
+    git:
+      url: https://github.com/GaloyMoney/concourse-shared.git
+      ref: b71d51f8293ef74c23d7ad5ff97c92fa3ea66a2e
+    includePaths:
+    - config/**/*
+    newRootPath: config


### PR DESCRIPTION
This PR adds in the main `vendir.yml` for adding tasks and configuration required by our CI to sync in common tasks from `concourse-shared`. The files added are part of the initial execution of `vendir sync`.