### PR TITLE
fix: update error level in critical methods

### DIFF
--- a/dealer/src/DealerRemoteWalletV2.ts
+++ b/dealer/src/DealerRemoteWalletV2.ts
@@ -150,7 +150,7 @@ export class DealerRemoteWalletV2 implements GaloyWallet {
             },
           }
         } catch (error) {
-          recordExceptionInCurrentSpan({ error, level: ErrorLevel.Warn })
+          recordExceptionInCurrentSpan({ error, level: ErrorLevel.Critical })
           logger.error(
             { query: BALANCE_QUERY, error },
             "{query} to galoy graphql api failed with {error}",
@@ -336,7 +336,7 @@ export class DealerRemoteWalletV2 implements GaloyWallet {
 
           return { ok: true, value: undefined }
         } catch (error) {
-          recordExceptionInCurrentSpan({ error, level: ErrorLevel.Warn })
+          recordExceptionInCurrentSpan({ error, level: ErrorLevel.Critical })
           logger.error(
             { mutation: MUTATIONS.onChainAddressCurrent, error },
             "{mutation} to galoy graphql api failed with {error}",

--- a/dealer/src/ExchangeBase.ts
+++ b/dealer/src/ExchangeBase.ts
@@ -115,7 +115,7 @@ export abstract class ExchangeBase {
             value: result,
           }
         } catch (error) {
-          recordExceptionInCurrentSpan({ error, level: ErrorLevel.Warn })
+          recordExceptionInCurrentSpan({ error, level: ErrorLevel.Critical })
           return { ok: false, error: error }
         }
       },
@@ -296,7 +296,7 @@ export abstract class ExchangeBase {
             },
           }
         } catch (error) {
-          recordExceptionInCurrentSpan({ error, level: ErrorLevel.Warn })
+          recordExceptionInCurrentSpan({ error, level: ErrorLevel.Critical })
           return { ok: false, error: error }
         }
       },
@@ -441,7 +441,7 @@ export abstract class ExchangeBase {
             },
           }
         } catch (error) {
-          recordExceptionInCurrentSpan({ error, level: ErrorLevel.Warn })
+          recordExceptionInCurrentSpan({ error, level: ErrorLevel.Critical })
           return { ok: false, error: error }
         }
       },
@@ -486,7 +486,7 @@ export abstract class ExchangeBase {
             },
           }
         } catch (error) {
-          recordExceptionInCurrentSpan({ error, level: ErrorLevel.Warn })
+          recordExceptionInCurrentSpan({ error, level: ErrorLevel.Critical })
           return { ok: false, error: error }
         }
       },
@@ -559,7 +559,7 @@ export abstract class ExchangeBase {
             value: result,
           }
         } catch (error) {
-          recordExceptionInCurrentSpan({ error, level: ErrorLevel.Warn })
+          recordExceptionInCurrentSpan({ error, level: ErrorLevel.Critical })
           return { ok: false, error: error }
         }
       },

--- a/dealer/src/OkexExchange.ts
+++ b/dealer/src/OkexExchange.ts
@@ -182,7 +182,7 @@ export class OkexExchange extends ExchangeBase {
             value: true,
           }
         } catch (error) {
-          recordExceptionInCurrentSpan({ error, level: ErrorLevel.Warn })
+          recordExceptionInCurrentSpan({ error, level: ErrorLevel.Critical })
           return { ok: true, value: true }
         }
       },


### PR DESCRIPTION
Update `recordExceptionInCurrentSpan` error level to `Critical` in the next methods:
 
Dealer wallet
- getWalletsBalances
- payOnChain

Exchange base 
- fetchDepositAddress
- transfer
- createMarketOrder
- fetchOrder
- fetchBalance

OkexExchange
- closePosition