### PR TITLE
feat: Overall PnL dashboard

### DIFF
--- a/grafana/provisioning/dashboards/galoy-dealer-overall-pnl.json
+++ b/grafana/provisioning/dashboards/galoy-dealer-overall-pnl.json
@@ -1,0 +1,420 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 1,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Price (USD)",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "hidden",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "avg(USD_price)",
+          "refId": "A"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Balances (USD)",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "editorMode": "code",
+          "expr": "avg(avg_over_time(galoy_dealer_swapUPnlInUsd[1h]))",
+          "hide": false,
+          "legendFormat": "Swap uPnL",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": null,
+          "editorMode": "code",
+          "expr": "avg(avg_over_time(galoy_dealer_fundingFeesTotalInSats[1h]))/1e8 * avg(avg_over_time(USD_price[1h]))",
+          "hide": false,
+          "legendFormat": "Funding fees",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": null,
+          "editorMode": "code",
+          "expr": "avg(avg_over_time(galoy_dealer_tradingFeesTotalInSats[1h]))/1e8 * avg(avg_over_time(USD_price[1h]))",
+          "hide": false,
+          "legendFormat": "Trading fees",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": null,
+          "editorMode": "code",
+          "expr": "( avg(avg_over_time(galoy_dealer_btcTotalBalance[1h])) + avg(avg_over_time(galoy_dealer_fundingAccountBtcTotalBalance[1h])) + (avg(avg_over_time(galoy_dealer_btc_balance[1h]))/1e8) + (avg(avg_over_time(galoy_dealer_tradingFeesTotalInSats[1h]))/1e8) + (avg(avg_over_time(galoy_dealer_fundingFeesTotalInSats[1h]) / 1e8)) ) * avg(avg_over_time(USD_price[1h])) + avg(avg_over_time(galoy_dealer_swapUPnlInUsd[1h]))",
+          "hide": false,
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "F"
+        },
+        {
+          "datasource": null,
+          "editorMode": "code",
+          "expr": "avg(avg_over_time(galoy_dealer_btcTotalBalance[1h])) * avg(avg_over_time(USD_price[1h]))",
+          "hide": false,
+          "legendFormat": "Exchange balance",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": null,
+          "editorMode": "code",
+          "expr": "avg(avg_over_time(galoy_dealer_fundingAccountBtcTotalBalance[1h])) * avg(avg_over_time(USD_price[1h]))",
+          "hide": false,
+          "legendFormat": "Exchange  funding account balance",
+          "range": true,
+          "refId": "G"
+        },
+        {
+          "datasource": null,
+          "editorMode": "code",
+          "expr": "avg(avg_over_time(galoy_dealer_btc_balance[1h]))/1e8 * avg(avg_over_time(USD_price[1h]))",
+          "hide": false,
+          "legendFormat": "Ledger wallet",
+          "range": true,
+          "refId": "H"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Position — Liability (USD)",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 26,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "hidden",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "avg(avg_over_time(galoy_dealer_exposureInUsd[1h]))+(avg(avg_over_time(galoy_dealer_usd_balance[1h]))/100)",
+          "refId": "A"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Balance — Liability (USD)",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 17
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "hidden",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "none",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "( avg(avg_over_time(galoy_dealer_btcTotalBalance[1h])) + avg(avg_over_time(galoy_dealer_fundingAccountBtcTotalBalance[1h])) + (avg(avg_over_time(galoy_dealer_btc_balance[1h]))/1e8) + (avg(avg_over_time(galoy_dealer_tradingFeesTotalInSats[1h]))/1e8) + (avg(avg_over_time(galoy_dealer_fundingFeesTotalInSats[1h]) / 1e8)) ) * avg(avg_over_time(USD_price[1h])) + avg(avg_over_time(galoy_dealer_swapUPnlInUsd[1h])) + (avg(avg_over_time(galoy_dealer_usd_balance[1h]))/100)",
+          "refId": "A"
+        }
+      ],
+      "type": "timeseries"
+    }
+  ],
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Galoy Dealer Overall PnL",
+  "uid": "8TUXhcgVz",
+  "version": 1,
+  "weekStart": ""
+}


### PR DESCRIPTION
Attempts to track the dealer's total balance of BTC
(across the ledger wallet and exchange accounts),
plus the unrealized PnL from the hedge position,
and compares the USD value of that sum
to the total USD liability.