### PR TITLE
fix: account for funds used to bootstrap dealer account

### DIFF
--- a/grafana/provisioning/dashboards/galoy-dealer.json
+++ b/grafana/provisioning/dashboards/galoy-dealer.json
@@ -3728,7 +3728,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "avg by(container) (avg_over_time(USD_price[1h])) * (avg by(container) (avg_over_time(galoy_dealer_btc_balance[1h])) / 100000000 + (avg by(container) (avg_over_time(galoy_dealer_btcTotalBalance[1h])) + avg by(container) (avg_over_time(galoy_dealer_fundingAccountBtcTotalBalance[1h])))) + avg by(container) (avg_over_time(galoy_dealer_swapUPnlInUsd[1h])) + (avg by(container) (avg_over_time(galoy_dealer_usd_balance[1h])) / 100)",
+          "expr": "avg by(container) (avg_over_time(USD_price[1h])) * (avg by(container) (avg_over_time(galoy_dealer_btc_balance[1h])) / 100000000 + (avg by(container) (avg_over_time(galoy_dealer_btcTotalBalance[1h])) + avg by(container) (avg_over_time(galoy_dealer_fundingAccountBtcTotalBalance[1h]))) - 0.32685100) + avg by(container) (avg_over_time(galoy_dealer_swapUPnlInUsd[1h])) + (avg by(container) (avg_over_time(galoy_dealer_usd_balance[1h])) / 100)",
           "interval": "",
           "legendFormat": "assets vs. liability",
           "refId": "A"


### PR DESCRIPTION
Currently the PnL panel on the grafana dashboard overstates
the overall PnL since it does not account for the initial funds deposited
into the exchange to bootstrap the dealer.